### PR TITLE
fix numerical overflow in pressure solve

### DIFF
--- a/channelflow/poissonsolver.cpp
+++ b/channelflow/poissonsolver.cpp
@@ -383,7 +383,6 @@ void PressureSolver::solve(FlowField& p, FlowField u) {
 
     for (int mx = mxlocmin; mx < mxlocmax; ++mx)
         for (int mz = mzlocmin; mz < mzlocmax; ++mz) {
-
             // Don't modify the mx=mz=0 (kx=kz=0) solution, dirichlet BCs are fine
             if (mx != 0 || mz != 0) {
                 Real lambda = helmholtz_[mx - mxlocmin][mz - mzlocmin].lambda();
@@ -397,14 +396,14 @@ void PressureSolver::solve(FlowField& p, FlowField u) {
                 diff2(vk, vkyy);
 
                 Complex alpha = nu_ * vkyy.eval_a() - pky.eval_a();
-                Complex beta  = nu_ * vkyy.eval_b() - pky.eval_b();
+                Complex beta = nu_ * vkyy.eval_b() - pky.eval_b();
 
                 // 2018-10-31, following jfg notes. Solve boundary value problem
                 // g''(y) - mu^2 g(y) = 0, g'(a) = alpha, g'(b) = beta
-                // using the general solution 
-                // g(y) = c exp(mu(y-a)) + d exp(-mu(y-b)) 
+                // using the general solution
+                // g(y) = c exp(mu(y-a)) + d exp(-mu(y-b))
                 // Determining constants c,d that match boundary conditions results
-                // in the formula below for c,d. Note that this particular formulation 
+                // in the formula below for c,d. Note that this particular formulation
                 // of the general solution is well-behaved numerically: both parts have
                 // max 1 at one boundary and approach 0 at the other. The prior
                 // formulation of the general solution and constants in terms of
@@ -412,11 +411,11 @@ void PressureSolver::solve(FlowField& p, FlowField u) {
                 // overflow for large mu and a,b.
 
                 // Compute the coefficients c,d that produce g(y) that matches BCs
-                Real mu = sqrt(lambda); // solutions are more easily in terms of mu=sqrt(lambda)
+                Real mu = sqrt(lambda);  // solutions are more easily in terms of mu=sqrt(lambda)
 
                 Real delta = mu * (1 - exp(-2 * mu * H));
-                Complex c = (-alpha + beta  * exp(-mu * H)) / delta;
-                Complex d = (  beta - alpha * exp(-mu * H)) / delta;
+                Complex c = (-alpha + beta * exp(-mu * H)) / delta;
+                Complex d = (beta - alpha * exp(-mu * H)) / delta;
 
                 // Evaluate g(y) at gridpoint values, transform to spectral, then add to p.
                 gk.setState(Physical);

--- a/channelflow/poissonsolver.cpp
+++ b/channelflow/poissonsolver.cpp
@@ -402,7 +402,7 @@ void PressureSolver::solve(FlowField& p, FlowField u) {
                 // 2018-10-31, following jfg notes. Solve boundary value problem
                 // g''(y) - mu^2 g(y) = 0, g'(a) = alpha, g'(b) = beta
                 // using the general solution 
-                // g(y) = c exp(mu(y-a)) + d exp(-mu(y-b))
+                // g(y) = c exp(mu(y-a)) + d exp(-mu(y-b)) 
                 // Determining constants c,d that match boundary conditions results
                 // in the formula below for c,d. Note that this particular formulation 
                 // of the general solution is well-behaved numerically: both parts have


### PR DESCRIPTION
This PR fixes issue https://github.com/epfl-ecps/channelflow/issues/4 , a numerical overflow issue for a boundary value problem in PressureSolver. It only gets triggered for y domains [a,b] with large a or b and very fine discretizations (large values of kx/Lx or kz/Lz). 

The prior formulation of the general solution of the BVP was g(y) = c exp(mu y) + d exp(-mu y), where mu = 2 pi sqrt( (kx/Lx)^2 + (kz/Lz)^2). The resultant formulae for c and d in terms of the boundary conditions have terms with exp(mu a) and exp(mu b). When I ran an ASBL simulation with [a,b] = [0,4], Lx=4, Lz=2, Nx = 128, Nz=162, this produced kxmax=41, kzmax=53 and and mu = 180, approximately. Then exp(mu b) = exp(720) = 5e312, which is overflow in double precision!

The solution is to reformulate the general solution as g(y) = c exp(mu(y-a)) + d exp(-mu(y-b)). Note that exp(mu(y-a)) and exp(-mu(y-b)) are bounded between 0 and 1 on the interval y in [a,b] for mu>0, and thus the formulae for the constants c and d are much better behaved --they involve exponentials only of the form exp(-mu H) where H = b-a, and it's fine if those underflow to zero. 

The reformulation passes pressureTest and my triggering ASBL case now computes fine.