### PR TITLE
HDF5 grid for padded fields

### DIFF
--- a/channelflow/flowfield.cpp
+++ b/channelflow/flowfield.cpp
@@ -2735,8 +2735,8 @@ void FlowField::hdf5Save(const string& filebase) const {
     // transfer to nopadded grid and save that
     int Nx, Nz;
     if (this->padded()) {
-        Nx = (2 * Nx_) / 3;
-        Nz = (2 * Nz_) / 3;
+        Nx = 2 * (Nx_ / 3);
+        Nz = 2 * (Nz_ / 3);
 
     } else {
         Nx = Nx_;


### PR DESCRIPTION
The number of actual grid points of saved FlowFields (in physical space) can differ between HDF5 and NetCDF formats. This only happens if dealiasing using the 2/3-rule was active while computing the FlowField.
Using NetCDF the x-grid without the padded modes is of size 2*(Nx/3).
Using HDF5 the x-grid without the padded modes was of size (2*Nx)/3. That was too conservative.

Thanks Pavan Kashyap for the bug report.

I adjusted the size for HDF5 files to be consistent with NetCDF. The 2/3-rule says that all modes `k` should be set to zero if `abs(k)>=N/3` (see Canuto et al. 2006, p.139). This way it is and was always implemented in Channelflow. Such a condition allows for the NetCDF style of saving using less points.

This fix does not impair backward compatibility of HDF5 since it affects the writing only.